### PR TITLE
levin should write the length of the array before write the array

### DIFF
--- a/portable-storage/src/lib.rs
+++ b/portable-storage/src/lib.rs
@@ -324,6 +324,7 @@ impl Array {
     fn write(buf: &mut BytesMut, array: &Array) {
         buf.reserve(1);
         buf.put_u8(array.serialize_type.unwrap());
+        raw_size::write(buf, array.array.len());
         for entry in array.array.iter() {
             StorageEntry::write(buf, &entry);
         }


### PR DESCRIPTION
```Rust
raw_size::write(buf, array.array.len());
```